### PR TITLE
Update Properties Table Management

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -19,13 +19,13 @@ async def main(validator):
     step = 1  # Initialize step
     current_thread = threading.current_thread().name
 
-    # Start the scoring thread
-    scoring_thread = threading.Thread(target=validator.scorer.run_score_thread, name=SCORE_THREAD_NAME)
-    scoring_thread.start()
-
     # Start the properties thread
     properties_thread = threading.Thread(target=validator.market_manager.ingest_properties, name=PROPERTIES_THREAD_NAME)
     properties_thread.start()
+
+    # Start the scoring thread
+    scoring_thread = threading.Thread(target=validator.scorer.run_score_thread, name=SCORE_THREAD_NAME)
+    scoring_thread.start()
 
     # Start the prediction sender thread
     prediction_sender_thread = threading.Thread(target=validator.prediction_sender.run, name=PREDICTION_SENDER_THREAD_NAME)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -11,6 +11,7 @@ from nextplace.validator.website_data.website_communicator import WebsiteCommuni
 
 SCORE_THREAD_NAME = "🏋🏻 ScoreThread 🏋"
 PREDICTION_SENDER_THREAD_NAME = "🛰 PredictionsTransmitter 🛰"
+PROPERTIES_THREAD_NAME = "🏠 PropertiesThread 🏠"
 
 
 async def main(validator):
@@ -21,6 +22,10 @@ async def main(validator):
     # Start the scoring thread
     scoring_thread = threading.Thread(target=validator.scorer.run_score_thread, name=SCORE_THREAD_NAME)
     scoring_thread.start()
+
+    # Start the properties thread
+    properties_thread = threading.Thread(target=validator.market_manager.ingest_properties, name=PROPERTIES_THREAD_NAME)
+    properties_thread.start()
 
     # Start the prediction sender thread
     prediction_sender_thread = threading.Thread(target=validator.prediction_sender.run, name=PREDICTION_SENDER_THREAD_NAME)
@@ -52,6 +57,12 @@ async def main(validator):
                     bt.logging.info(f"| {current_thread} | ☢️ ScoreThread was found not running, restarting it...")
                     scoring_thread = threading.Thread(target=validator.scorer.run_score_thread, name=SCORE_THREAD_NAME)
                     scoring_thread.start()
+
+                properties_thread_is_alive = validator.is_thread_running(PROPERTIES_THREAD_NAME)
+                if not properties_thread_is_alive:
+                    bt.logging.info(f"| {current_thread} | ☢️ PropertiesThread was found not running, restarting it...")
+                    properties_thread = threading.Thread(target=validator.market_manager.ingest_properties, name=PROPERTIES_THREAD_NAME)
+                    properties_thread.start()
 
                 prediction_sender_thread_is_alive = validator.is_thread_running(PREDICTION_SENDER_THREAD_NAME)
                 if not prediction_sender_thread_is_alive:

--- a/nextplace/validator/api/properties_api.py
+++ b/nextplace/validator/api/properties_api.py
@@ -60,7 +60,7 @@ class PropertiesAPI(ApiBase):
             if len(homes) < self.max_results_per_page:  # Last page
                 break
 
-            bt.logging.trace(f"| {current_thread} | Ingested {len(homes)} homes on page {page}")
+            bt.logging.trace(f"| {current_thread} | Ingested {len(homes)} homes on page {page} in {market['name']}")
             page += 1
 
     def _ingest_properties(self, homes: list, market: str) -> None:

--- a/nextplace/validator/market/market_manager.py
+++ b/nextplace/validator/market/market_manager.py
@@ -63,14 +63,16 @@ class MarketManager:
         market_index = self._find_initial_market_index()
         
         # Keep at least (x) synapses worth of properties in the table at all times
-        number_of_stored_synapse_data_items = 5
-        min_properties_table_size = NUMBER_OF_PROPERTIES_PER_SYNAPSE * number_of_stored_synapse_data_items
+        number_of_synapses = 5
+        min_properties_table_size = NUMBER_OF_PROPERTIES_PER_SYNAPSE * number_of_synapses
         
         while True:
             
             # Get size of properties table
             with self.database_manager.lock:
                 size_of_properties_table = self.database_manager.get_size_of_table('properties')
+
+            bt.logging.info(f"| {current_thread} | {size_of_properties_table} items in property table")
                 
             # If size is less than our min, get more properties
             if size_of_properties_table < min_properties_table_size:

--- a/nextplace/validator/market/market_manager.py
+++ b/nextplace/validator/market/market_manager.py
@@ -2,6 +2,9 @@ import bittensor as bt
 from nextplace.validator.api.properties_api import PropertiesAPI
 from nextplace.validator.database.database_manager import DatabaseManager
 import threading
+from time import sleep
+
+from nextplace.validator.utils.contants import SYNAPSE_TIMEOUT, NUMBER_OF_PROPERTIES_PER_SYNAPSE
 
 """
 Helper class manages the real estate market
@@ -9,15 +12,11 @@ Helper class manages the real estate market
 
 
 class MarketManager:
+
     def __init__(self, database_manager: DatabaseManager, markets: list[dict[str, str]]):
         self.database_manager = database_manager
         self.markets = markets
         self.properties_api = PropertiesAPI(database_manager, markets)
-        self.lock = threading.RLock()  # Reentrant lock for thread safety
-        current_thread = threading.current_thread().name
-        initial_market_index = self._find_initial_market_index()
-        bt.logging.info(f"| {current_thread} | 🏁 Initial market index: {initial_market_index}")
-        self.market_index = initial_market_index  # Index into self.markets. The current market
 
     def _find_initial_market_index(self) -> int:
         """
@@ -42,6 +41,8 @@ class MarketManager:
         some_property = self.database_manager.query("""
             SELECT market
             FROM properties
+            ORDER BY query_date
+            DESC
             LIMIT 1
         """)
         if some_property:
@@ -51,17 +52,33 @@ class MarketManager:
         return 0
 
 
-    def get_properties_for_market(self) -> None:
+    def ingest_properties(self) -> None:
         """
         RUN IN THREAD
-        Hit the API, update the database
+        Populate the properties table with properties
         Returns:
             None
         """
-        current_thread = threading.current_thread().name
-        bt.logging.info(f"| {current_thread} | 🔑 No properties were found, getting the next market and updating properties")
-        current_market = self.markets[self.market_index]  # Extract market object
-        self.properties_api.process_region_market(current_market)  # Populate database with this market
-        with self.lock:  # Acquire lock
-            bt.logging.info(f"| {current_thread} | ✅ Finished ingesting properties in {current_market['name']}")
-            self.market_index = self.market_index + 1 if self.market_index < len(self.markets) - 1 else 0 # Wrap index around
+        current_thread = threading.current_thread().name  # Get thread name
+        market_index = self._find_initial_market_index()
+        
+        # Keep at least (x) synapses worth of properties in the table at all times
+        number_of_stored_synapse_data_items = 5
+        min_properties_table_size = NUMBER_OF_PROPERTIES_PER_SYNAPSE * number_of_stored_synapse_data_items
+        
+        while True:
+            
+            # Get size of properties table
+            with self.database_manager.lock:
+                size_of_properties_table = self.database_manager.get_size_of_table('properties')
+                
+            # If size is less than our min, get more properties
+            if size_of_properties_table < min_properties_table_size:
+                current_market = self.markets[market_index]  # Extract market object
+                self.properties_api.process_region_market(current_market)  # Populate database with this market
+                bt.logging.info(f"| {current_thread} | ✅ Finished ingesting properties in {current_market['name']}")
+                market_index = market_index + 1 if market_index < len(self.markets) - 1 else 0  # Wrap index around
+                
+            # If we're still good on size, just sleep until another synapse goes out
+            else:
+                sleep(SYNAPSE_TIMEOUT)

--- a/nextplace/validator/nextplace_validator.py
+++ b/nextplace/validator/nextplace_validator.py
@@ -88,10 +88,11 @@ class RealEstateValidator(BaseValidatorNeuron):
 
         with self.database_manager.lock:
             synapse: RealEstateSynapse or None = self.synapse_manager.get_synapse()  # Prepare data for miners
-            if synapse is None or len(synapse.real_estate_predictions.predictions) == 0:  # No data in Properties table yet
-                bt.logging.trace(f"| {self.current_thread} | ↻ No data in Synapse. Waiting for PropertiesThread to update the Properties table.")
-                self.should_step = False
-                return
+
+        if synapse is None or len(synapse.real_estate_predictions.predictions) == 0:  # No data in Properties table yet
+            bt.logging.trace(f"| {self.current_thread} | ↻ No data in Synapse. Waiting for PropertiesThread to update the Properties table.")
+            self.should_step = False
+            return
 
         # Get list of all nextplace IDs in this synapse
         synapse_ids = set([x.nextplace_id for x in synapse.real_estate_predictions.predictions])

--- a/nextplace/validator/nextplace_validator.py
+++ b/nextplace/validator/nextplace_validator.py
@@ -78,7 +78,7 @@ class RealEstateValidator(BaseValidatorNeuron):
                 return True
         return False
 
-    async def forward(self, step: int) -> None:
+    def forward(self, step: int) -> None:
         """
         Forward pass
         Returns:

--- a/nextplace/validator/nextplace_validator.py
+++ b/nextplace/validator/nextplace_validator.py
@@ -101,8 +101,10 @@ class RealEstateValidator(BaseValidatorNeuron):
                 self.should_step = False
                 return
 
+            # Get list of all nextplace IDs in this synapse
             synapse_ids = set([x.nextplace_id for x in synapse.real_estate_predictions.predictions])
 
+            # Query the metagraph
             all_responses = self.dendrite.query(
                 axons=self.metagraph.axons,
                 synapse=synapse,

--- a/nextplace/validator/nextplace_validator.py
+++ b/nextplace/validator/nextplace_validator.py
@@ -95,16 +95,10 @@ class RealEstateValidator(BaseValidatorNeuron):
             return
 
         try:
-            # If we don't have any properties AND we aren't getting them yet, start thread to get properties
-            number_of_properties = self.database_manager.get_size_of_table('properties')
-            if number_of_properties == 0:
-                bt.logging.info(f"| {self.current_thread} | 🏘️ No properties in the properties table. PropertiesThread should be updating this table.")
+            synapse: RealEstateSynapse or None = self.synapse_manager.get_synapse()  # Prepare data for miners
+            if synapse is None or len(synapse.real_estate_predictions.predictions) == 0:  # No data in Properties table yet
+                bt.logging.trace(f"| {self.current_thread} | ↻ No data in Synapse. Waiting for PropertiesThread to update the Properties table.")
                 self.should_step = False
-                return
-
-            synapse: RealEstateSynapse = self.synapse_manager.get_synapse()  # Prepare data for miners
-            if synapse is None or len(synapse.real_estate_predictions.predictions) == 0:
-                bt.logging.trace(f"| {self.current_thread} | ↻ No data for Synapse, returning.")
                 return
 
             synapse_ids = set([x.nextplace_id for x in synapse.real_estate_predictions.predictions])

--- a/nextplace/validator/synapse/synapse_manager.py
+++ b/nextplace/validator/synapse/synapse_manager.py
@@ -59,8 +59,8 @@ class SynapseManager:
 
             real_estate_predictions = RealEstatePredictions(predictions=outgoing_data)
             synapse = RealEstateSynapse.create(real_estate_predictions=real_estate_predictions)
-            market_index = 20
-            market = property_data[0][market_index]
+            market_name_index = 20
+            market = property_data[0][market_name_index]
             bt.logging.trace(f"| {current_thread} | ✉️ Created Synapse with {len(outgoing_data)} properties in {market}")
             return synapse
 

--- a/nextplace/validator/utils/contants.py
+++ b/nextplace/validator/utils/contants.py
@@ -1,5 +1,6 @@
 ISO8601 = "%Y-%m-%dT%H:%M:%SZ"
 NUMBER_OF_PROPERTIES_PER_SYNAPSE = 1200
+SYNAPSE_TIMEOUT = 150
 
 
 def build_miner_predictions_table_name(miner_hotkey):

--- a/nextplace/validator/website_data/miner_score_sender.py
+++ b/nextplace/validator/website_data/miner_score_sender.py
@@ -65,7 +65,7 @@ class MinerScoreSender:
                     num_predictions += result[1]
                 try:
                     total_predictions = self.database_manager.get_size_of_table(f"predictions_{hotkey}")
-                except OperationalError:
+                except OperationalError or IndexError:
                     total_predictions = 0
                 scored_list = [{'date': key, 'totalScored': value} for key, value in date_score_map.items()]
                 scored_list.sort(key=lambda x: x['date'], reverse=True)

--- a/nextplace/validator/website_data/website_communicator.py
+++ b/nextplace/validator/website_data/website_communicator.py
@@ -54,7 +54,6 @@ class WebsiteCommunicator:
             None
         """
         current_thread = threading.current_thread().name
-        bt.logging.info(f"| {current_thread} | 🛰 Trying to send {len(data)} datapoints to the web server asynchronously.")
 
         async with aiohttp.ClientSession() as session:
             try:
@@ -65,7 +64,7 @@ class WebsiteCommunicator:
                 ) as response:
                     response_text = await response.text()
                     if response.status == 200 or response.status == 201:
-                        bt.logging.info(f"| {current_thread} | ✅ Data sent to Nextplace web server successfully.")
+                        pass
                     else:
                         if not self.suppress_errors:
                             bt.logging.warning(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nextplace
-version = 2.3.0
+version = 2.3.1
 database_version = 1.0.0
 reset_validator_scores = False
 author = estatecat, nextplacelynx, fivedollarwitch


### PR DESCRIPTION
- Maintain at least (<size_of_synapse> x 5) properties in the properties table at all times 
    - This means that _every synapse_ is full (except when the validator launches for the first time - the first synapse won't be full).
    - New miners will get up to speed faster because we're collecting data much faster with full synapses
- Adjust lock scope so that properties can be ingested and miners can be scored while the metagraph is being queried
     - This allows for **much** better thread interleaving thus speeding up scoring and property ingestion